### PR TITLE
Update OllamaSettingTab.ts

### DIFF
--- a/src/OllamaSettingTab.ts
+++ b/src/OllamaSettingTab.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import { App, Notice, PluginSettingTab, Setting, DropdownComponent, requestUrl, Modal } from "obsidian";
 import { DEFAULT_SETTINGS } from "data/defaultSettings";
 import { OllamaCommand } from "model/OllamaCommand";
 import { Ollama } from "Ollama";
@@ -22,7 +22,7 @@ export class OllamaSettingTab extends PluginSettingTab {
       .addText((text) =>
         text
           .setPlaceholder("http://localhost:11434")
-          .setValue(this.plugin.settings.ollamaUrl)
+          .setValue(this.plugin.settings?.ollamaUrl)
           .onChange(async (value) => {
             this.plugin.settings.ollamaUrl = value;
             await this.plugin.saveSettings();
@@ -30,24 +30,51 @@ export class OllamaSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
-      .setName("default model")
-      .setDesc("Name of the default ollama model to use for prompts")
-      .addText((text) =>
-        text
-          .setPlaceholder("llama2")
-          .setValue(this.plugin.settings.defaultModel)
-          .onChange(async (value) => {
-            this.plugin.settings.defaultModel = value;
-            await this.plugin.saveSettings();
-          })
-      );
+      .setName("Default Model")
+      .setDesc("Set the default Ollama model to use for completions")
+      .addDropdown(async (dropdown: DropdownComponent) => {
+        dropdown.addOption(this.plugin.settings?.defaultModel, this.plugin.settings?.defaultModel);
+        dropdown.onChange(async (value: string) => {
+          this.plugin.settings.defaultModel = value;
+          await this.plugin.saveSettings();
+        });
+
+        await this.fetchAndPopulateModels(dropdown);
+      });
+
+    const setting = new Setting(this.containerEl)
+      .setName("Refresh Models")
+      .setDesc("Refresh the list of available Ollama models")
+      .addButton((button) => {
+        button.setButtonText("Refresh");
+        button.onClick(async () => {
+          const buttonEl = this.containerEl.querySelector('.setting-item-control button') as HTMLButtonElement;
+          if (buttonEl) {
+            buttonEl.disabled = true;
+          }
+
+          const selectEl = setting.controlEl.querySelector('select');
+          const dropdownComponent = (selectEl as any).obsidianComponent as DropdownComponent;
+
+          if (dropdownComponent) {
+            new Notice("Model list refreshing...");
+            await this.fetchAndPopulateModels(dropdownComponent);
+          } else {
+            new Notice("Dropdown not found. Please try again.");
+          }
+
+          if (buttonEl) {
+            buttonEl.disabled = false;
+          }
+        });
+      });
 
     containerEl.createEl("h3", { text: "Commands" });
 
     const newCommand: OllamaCommand = {
       name: "",
       prompt: "",
-      model: "",
+      model: this.plugin.settings?.defaultModel || "",
       temperature: undefined,
     };
 
@@ -69,12 +96,33 @@ export class OllamaSettingTab extends PluginSettingTab {
         });
       });
 
-    new Setting(containerEl).setName("New command model").addText((text) => {
-      text.setPlaceholder("e.g. llama2");
-      text.onChange(async (value) => {
-        newCommand.model = value;
+    // New command model setting with dropdown and "Default" option
+    new Setting(containerEl)
+      .setName("New command model")
+      .setDesc("Select the Ollama model to use for this command. Choose 'Default' to use the default model.")
+      .addDropdown(async (dropdown: DropdownComponent) => {
+        // Add "Default" option first
+        dropdown.addOption("Default", "Default");
+
+        // Fetch and populate the rest of the models
+        await this.fetchAndPopulateModels(dropdown);
+
+        // Ensure "Default" is selected initially if newCommand.model is undefined
+        if (!newCommand.model) {
+          dropdown.setValue("Default");
+        } else {
+          // Type assertion to ensure newCommand.model is a string
+          dropdown.setValue(newCommand.model as string);
+        }
+
+        dropdown.onChange(async (value: string) => {
+          if (value === "Default") {
+            delete newCommand.model;
+          } else {
+            newCommand.model = value;
+          }
+        });
       });
-    });
 
     new Setting(containerEl)
       .setName("New command temperature")
@@ -96,7 +144,7 @@ export class OllamaSettingTab extends PluginSettingTab {
           }
 
           if (
-            this.plugin.settings.commands.find(
+            this.plugin.settings?.commands.find(
               (command) => command.name === newCommand.name
             )
           ) {
@@ -111,8 +159,9 @@ export class OllamaSettingTab extends PluginSettingTab {
             return;
           }
 
-          if (!newCommand.model) {
-            new Notice("Please enter a model for the command.");
+          // Check if a model is selected or default is used
+          if (!newCommand.model && !this.plugin.settings?.defaultModel) {
+            new Notice("Please select a model or set a default model.");
             return;
           }
 
@@ -124,19 +173,52 @@ export class OllamaSettingTab extends PluginSettingTab {
 
     containerEl.createEl("h4", { text: "Existing Commands" });
 
-    this.plugin.settings.commands.forEach((command) => {
+    this.plugin.settings?.commands.forEach(async (command: OllamaCommand) => {
       new Setting(containerEl)
         .setName(command.name)
-        .setDesc(`${command.prompt} - ${command.model}`)
+        .setDesc(`${command.prompt} - ${command.model || "Default"}`)
         .addButton((button) =>
-          button.setButtonText("Remove").onClick(async () => {
-            this.plugin.settings.commands =
-              this.plugin.settings.commands.filter(
-                (c) => c.name !== command.name
+          button
+            .setButtonText("Remove")
+            .onClick(async () => {
+              this.plugin.settings.commands = this.plugin.settings?.commands.filter(
+                (c: OllamaCommand) => c.name !== command.name
               );
-            await this.plugin.saveSettings();
-            this.display();
-          })
+              await this.plugin.saveSettings();
+              this.display();
+            })
+        )
+        .addButton((button) =>
+          button
+            .setButtonText("Meta-Bind Button")
+            .onClick(async () => {
+              const commandName = command.name.toLowerCase().replace(/\s+/g, '-');
+              const buttonCode = `\`BUTTON[${commandName}]\`\n\`\`\`meta-bind-button
+label: "${command.name}"
+icon: ""
+hidden: true
+class: ""
+tooltip: ""
+id: "${commandName}"
+style: default
+
+actions:
+ - type: command
+   command: ollama:${commandName}
+\`\`\`
+`;
+              navigator.clipboard.writeText(buttonCode).then(() => {
+                new Notice("Button code copied to clipboard!");
+              });
+            })
+        )
+        // Add the new "Edit" button
+        .addButton((button) =>
+          button
+            .setButtonText("Edit")
+            .onClick(async () => {
+              this.openEditCommandModal(command); // Open the edit modal
+            })
         );
     });
 
@@ -151,7 +233,7 @@ export class OllamaSettingTab extends PluginSettingTab {
         button.setWarning();
         return button.setButtonText("Update").onClick(async () => {
           DEFAULT_SETTINGS.commands.forEach((command) => {
-            const existingCommand = this.plugin.settings.commands.find(
+            const existingCommand = this.plugin.settings?.commands.find(
               (c) => c.name === command.name
             );
 
@@ -160,7 +242,7 @@ export class OllamaSettingTab extends PluginSettingTab {
               existingCommand.model = command.model;
               existingCommand.temperature = command.temperature;
             } else {
-              this.plugin.settings.commands.push(command);
+              this.plugin.settings?.commands.push(command);
             }
           });
           await this.plugin.saveSettings();
@@ -181,5 +263,125 @@ export class OllamaSettingTab extends PluginSettingTab {
           this.display();
         });
       });
+  }
+
+  public async fetchAndPopulateModels(dropdown: DropdownComponent) { 
+    try {
+      const response = await requestUrl({
+        url: `${this.plugin.settings?.ollamaUrl}/api/tags`,
+        method: 'GET',
+      });
+
+      if (!response || response.status < 200 || response.status >= 300) {
+        throw new Error(`Failed to fetch models. Status: ${response.status}`);
+      }
+
+      const data = JSON.parse(await response.text) as { models: { name: string }[] };
+      const models = data.models;
+
+      if (Array.isArray(models)) {
+        if (dropdown.selectEl) {
+          dropdown.selectEl.innerHTML = '';
+
+          // Add "Default" option to the beginning of the models array
+          models.unshift({ name: "Default" });
+
+          const optgroup = document.createElement('optgroup');
+          optgroup.label = 'Ollama Models';
+
+          for (const modelObj of models) {
+            const option = document.createElement('option');
+            option.value = modelObj.name;
+            option.text = modelObj.name;
+            optgroup.appendChild(option);
+          }
+
+          dropdown.selectEl.appendChild(optgroup);
+          new Notice("Models refreshed successfully!");
+        }
+      } else {
+        console.error("Unexpected response from Ollama server:", models);
+        new Notice("Failed to refresh models. Unexpected server response.");
+      }
+
+    } catch (error) {
+      console.error("Error fetching models:", error);
+      new Notice("Failed to refresh models. Please check your Ollama URL and try again.");
+    }
+  }
+
+  private openEditCommandModal(command: OllamaCommand) {
+    new EditCommandModal(this.app, this.plugin, command, this, async (updatedCommand) => {
+      const commandIndex = this.plugin.settings.commands.findIndex(c => c.name === command.name);
+
+      if (commandIndex !== -1) {
+        this.plugin.settings.commands[commandIndex] = updatedCommand;
+        await this.plugin.saveSettings();
+        this.display(); 
+      }
+    }).open();
+  }
+}
+
+class EditCommandModal extends Modal {
+  command: OllamaCommand;
+  onSave: (updatedCommand: OllamaCommand) => void;
+  settingsTab: OllamaSettingTab;
+
+  constructor(app: App, plugin: Ollama, command: OllamaCommand, settingsTab: OllamaSettingTab, onSave: (updatedCommand: OllamaCommand) => void) {
+    super(app);
+    this.command = command;
+    this.onSave = onSave;
+    this.settingsTab = settingsTab;
+  }
+
+  onOpen() {
+    const { contentEl } = this;
+
+    contentEl.createEl("h2", { text: `Edit Command: ${this.command.name}` });
+
+    new Setting(contentEl)
+      .setName("Prompt")
+      .addTextArea((text) => {
+        text.setValue(this.command.prompt);
+        text.onChange(async (value) => { this.command.prompt = value; });
+      });
+
+    new Setting(contentEl)
+      .setName("Model")
+      .setDesc("Select the Ollama model or 'Default'")
+      .addDropdown(async (dropdown: DropdownComponent) => {
+        dropdown.addOption("Default", "Default");
+        await this.settingsTab.fetchAndPopulateModels(dropdown);
+
+        dropdown.setValue(this.command.model || "Default");
+        dropdown.onChange(async (value: string) => {
+          if (value === "Default") { delete this.command.model; } 
+          else { this.command.model = value; }
+        });
+      });
+
+    new Setting(contentEl)
+      .setName("Temperature")
+      .addSlider((slider) => {
+        slider.setLimits(0, 1, 0.01);
+        slider.setValue(this.command.temperature || 0.2); 
+        slider.onChange(async (value) => { this.command.temperature = value; });
+      });
+
+    new Setting(contentEl)
+      .addButton((btn) => 
+        btn.setButtonText("Save")
+          .setCta()
+          .onClick(async () => { 
+            this.onSave(this.command);
+            this.close();
+          })
+      );
+  }
+
+  onClose() {
+    const { contentEl } = this;
+    contentEl.empty();
   }
 }


### PR DESCRIPTION
Here are some changes.
1. Dropdown Menu that lets you change default model.
2. Drop down models for add command.
3. Edit button for commands.
4. Meta-Bind Button - This lets copies a script to clipboard that makes a quick button to click that runs commands. relies on Meta-Bind Plugin.

![image](https://github.com/user-attachments/assets/2234c81f-97ed-4880-9124-c7a4474a3aab)
Here is an example of buttons in a side bar that can be made to have quick access to custom commands.

Recommended to add https://github.com/pjeby/pane-relief so you can lock the side window from stealing focus from the note.  